### PR TITLE
[finish] 投稿日時の並び替えエラー

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -50,7 +50,7 @@ class Post < ApplicationRecord
     #byebug
     self.custom_order_scope('star', 'DESC')
    when "投稿日時が新しい投稿から"
-    self.custom_order_scope('created_at', 'DESC')
+    self.custom_order_scope('posts.created_at', 'DESC')
    when "価格が安い商品から"
     self.includes(:item).custom_order_scope('items.price', 'ASC')
    when "価格が高い商品から"


### PR DESCRIPTION
投稿日時の並び替えと絞り込み検索を両立した際に、発生していたエラーを解消しました。