### PR TITLE
[finish] itemコントローラの修正　priceの絞り込み表示

### DIFF
--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -8,7 +8,7 @@ class Public::ItemsController < ApplicationController
   @search = params[:search]
   @order = params[:order]
   
-  if @search.present? || @min_price.present? || @max_price.present? || @order.present?
+  if @search.present? || @min_price.present? && @max_price.present? || @order.present?
    @items = Item.combined_items_genre_search_and_price_range_and_order(@search, @min_price, @max_price, @order)
   else
    @items = Item.all


### PR DESCRIPTION
itemコントローラにおいて、priceの最低金額、最高金額の一方が入力されていないとエラーが発生していたので、条件分岐を修正しました。