### PR TITLE
[finish] フォローを外す機能の修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,7 +65,7 @@ class User < ApplicationRecord
   end
   
   def unfollow(user_id)
-    activerelationships.find_by(followed_id: user_id).destroy
+    active_relationships.find_by(followed_id: user_id).destroy
   end
   
   def following?(user)


### PR DESCRIPTION
unfollowメソッドにスペルミスがあり、不具合が生じていた為修正しました。