### PR TITLE
[finish] spec/modelsへの記述

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
   has_many :followeds, through: :passive_relationships, source: :follower
   has_many :notifications, dependent: :destroy
   has_one_attached :profile_image
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true, length: {in: 2..20}
 
   def get_profile_image(width, height)
     unless profile_image.attached?

--- a/spec/models/donation_destination_spec.rb
+++ b/spec/models/donation_destination_spec.rb
@@ -1,0 +1,20 @@
+require 'rails-helper'
+
+RSpec.describe DonationDestination, 'DonationDestinationモデルのテスト', type: :model do
+    describe '空白のバリデーションチェック' do
+        it 'nameが空白の場合にエラーメッセージが表示されるか', spec_category: "バリデーションとメッセージ表示" do
+            donation_destination = FactoryBot.build(:donation_destination, name: '')
+            expect(donation_destination.errors.messages[:name]).to_include("can't be blank")
+            expect(page).to have_content '寄付先を入力してください'
+        end
+        
+    end
+    
+    describe 'アソシエーションのテスト' do
+        context 'Itemモデルとの関係' do
+            it '1:Nとなっている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+                expect(DonationDestination.reflect_on_association(:items).macro).to eq :has_many
+            end
+        end
+    end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,39 @@
+require 'rails-helper'
+
+Rspec.describe Item, 'Itemモデルに関するテスト', type: :model do
+    
+    describe '空白のバリデーションチェック' do
+        it 'nameが空白の場合にエラーメッセージが表示されるか', spec_category: "バリデーションとメッセージの表示" do
+            item = FactoryBot.build(:item, name: '')
+            expect(item.errors.messages[:name]).to_include("can't be blank")
+            expect(page).to have_content('商品名を入力してください')
+        end
+        
+        it 'priceが空白の場合にエラーメッセージが表示されるか', spec_category: "バリデーションとメッセージの表示" do
+            item = FactoryBot.build(:item, price: '')
+            expect(item.errors.messages[:price]).to_include("can't be blank")
+            expect(page).to have_content('価格を入力してください')
+        end
+    end
+    
+    describe 'アソシエーションのテスト' do
+        context 'Genreモデルとの関係' do
+            it 'N:1となっている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+                expect(Item.reflect_on_association(:genre).macro).to eq :belongs_to
+            end
+        end
+        
+        context 'DonationDestinationモデルとの関係' do
+            it 'N:1となっている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+                expect(Item.reflect_on_association(:donation_destination).macro).to eq :belongs_to
+            end
+        end
+        
+        context 'Postモデルとの関係' do
+            it '1:Nとなっている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+                expect(Item.reflect_on_association(:posts).macro).to eq :has_many
+            end
+        end
+        
+    end
+end

--- a/spec/models/post_comment_spec.rb
+++ b/spec/models/post_comment_spec.rb
@@ -1,0 +1,25 @@
+require 'rails-helper'
+
+RSpec.describe PostComment, 'PostCommentモデルのテスト', type: :model do
+    describe '空白のバリデーションチェック' do
+        it 'commentが空白の場合にエラーメッセージが表示されるか', spec_category: "バリデーションとメッセージ表示" do
+            post_comment = FactoryBot.build(:post_comment, comment: '')
+            expect(post_comment.errors.messages[:post_comment]).to_include("can't be blank")
+            expect(page).to have_content 'コメントを入力してください'
+        end
+    end
+    
+    describe 'アソシエーションのテスト' do
+        context 'Postモデルとの関係' do
+            it 'N:1となっている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+                expect(PostComment.reflect_on_association(:post).macro).to eq :belongs_to
+            end
+        end
+        
+        context 'Userモデルとの関係' do
+            it 'N:1となっている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+                expect(PostComment.reflect_on_association(:user).macro).to eq :belongs_to
+            end
+        end
+    end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+Rspec.describe Post, 'Postモデルに関するテスト', type: :model do
+
+    describe '空白のバリデーションチェック' do
+        it 'titleが空白の場合にエラーメッセージが表示されるか', spec_category: "バリデーションとメッセージ表示" do
+            post = FactoryBot.build(:post, title: '')
+            expect(post).to be_invalid
+            expect(post.errors.messages[:title]).to_include("can't be blank")
+            expect(page).to have_content 'タイトルを入力してください'
+        end
+        
+        it 'bodyが空白の場合にエラーメッセージが表示されるか', spec_category: "バリデーションとメッセージ表示" do
+            post = FactoryBot.build(:post, body: '')
+            expect(post).to be_invalid
+            expect(post.errors.messages[:body]).to_include("can't be blank")
+            expect(page).to have_content '本文を入力してください'
+        end
+        
+        it 'starが空白の場合にエラーメッセージが表示されるか', spec_category: "バリデーションとメッセージ表示" do
+            post = FactoryBot.build(:post, star: '')
+            expect(post).to be_invalid
+            expect(post.errors.messages[:star]).to_include("can't be blank")
+            expect(page).to have_content '評価を入力してください'
+        end
+        
+        it 'tagが空白の場合にエラーメッセージが表示されるか', spec_category: "バリデーションとメッセージ表示" do
+            post = FactoryBot.build(:post, tag: '')
+            expect(post).to be_invalid
+            expect(post.errors.messages[:tag]).to_include("can't be blank")
+            expect(page).to have_content 'タグを入力してください'  
+        end
+    end
+    
+    describe 'アソシエーションのテスト' do
+       context 'Userモデルとの関係' do
+           it 'N:1となっている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+               expect(Post.reflect_on_association(:user).macro).to eq :belongs_to
+           end
+       end 
+       
+       context 'Itemモデルとの関係' do
+           it 'N:1となっている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+               expect(Post.reflect_on_association(:item).macro).to eq :belongs_to
+           end
+       end
+       
+       context 'PostCommentモデルとの関係' do
+           it '1:Nとなっている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+               expect(Post.reflect_on_association(:post_comments).macro).to eq :has_many
+           end
+       end
+    end
+end
+    

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,53 @@
+require 'rails-helper'
+
+RSpec.describe User, 'Userモデルのテスト', type: :model do
+    describe 'バリデーションのテスト' do
+        context 'nameカラムのバリデーションチェック' do
+            it 'nameが空白の場合にエラーメッセージが表示されるか', spec_category: "バリデーションとメッセージ表示" do
+               user = FactoryBot.build(:user, name: '')
+               expect(user.errors.messages[:name]).to_include("can't be blank")
+               expect(page).to have_content 'ニックネームを入力してください'
+            end
+            
+            it '2文字以上であること: 1文字は×', spec_category: "バリデーションとメッセージ表示" do
+                user.name = Faker::Lorem.characters(number: 1)
+                is_expected.to eq false
+            end
+            
+            it '２文字以上であること: 2文字は○', spec_category: "バリデーションとメッセージ表示" do
+                user.name = Faker::Lorem.characters(number: 2)
+                is_expected.to eq true
+            end
+            
+            it '20文字以下であること: 20文字は○', spec_category: "バリデーションとメッセージ表示" do
+                user.name = Faker::Lorem.characters(number: 20)
+                is_expected.to eq true
+            end
+            
+            it '20文字以下であること: 21文字は×', spec_category: "バリデーションとメッセージ表示" do
+                user.name = Faker::Lorem.characters(number: 21)
+                is_expected.to eq false
+            end
+            
+            it '一意性があること', spec_category: "バリデーションとメッセージ表示" do
+                user.name = other_user.name
+                is_expected.to eq false
+            end
+        end
+        
+    end
+    
+    describe 'アソシエーションのテスト' do
+        context 'Postモデルとの関係' do
+            it '1:Nになっている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+                expect(User.reflect_on_association(:posts).macro).to eq :has_many
+            end
+        end
+        
+        context 'PostCommentモデルとの関係' do
+            it '1:Nになっている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+                expect(User.reflect_on_association(:post_comments).macro).to eq :has_many
+            end
+        end
+    end
+end


### PR DESCRIPTION
specフォルダ配下へmodelsフォルダを作成しました。
その中で各モデルに対して、バリデーションとアソシエーションのテスト項目を記述しました。
また、Userのnameカラムに関して、文字数や一意性を確保する為にバリデーションを追加しました。