### PR TITLE
[finish] ログイン後のトップページ修正

### DIFF
--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -26,12 +26,19 @@
    </div>
   </div>
   <div class= "col-lg-4 col-md-3 col-sm-12 p-3">
+   <% if current_user.present? %>
+     <div class= "button mx-auto mt-5 mb-2">
+      <%= link_to mypage_path, class: 'btn btn-secondary btn-lg d-flex align-items-center justify-content-center' do %>
+       マイページ
+      <% end %>
+     </div>
+   <% else %>
      <div class= "button mx-auto mt-5 mb-2">
       <%= link_to  new_user_registration_path, class: 'btn btn-primary btn-lg d-flex align-items-center justify-content-center' do %>
        <i class="fa-solid fa-user-plus mr-2"></i>新規登録
       <% end %>
      </div>
-
+     
      <div class= "button mx-auto mb-2">
       <%= link_to new_user_session_path, class: 'btn btn-success btn-lg d-flex align-items-center justify-content-center' do %>
        <i class="fa-solid fa-right-to-bracket mr-2"></i>ログイン
@@ -40,9 +47,10 @@
      
      <div class= "button mx-auto mb-2">
       <%= link_to user_guest_sign_in_path, method: :post, class: 'btn btn-secondary btn-lg d-flex align-items-center justify-content-center' do %>
-      ゲストログイン(閲覧用)
+       ゲストログイン(閲覧用)
       <% end %>
      </div>
+   <% end %>
   </div>
  </div>
 </div>

--- a/spec/system/02_after_login_spec.rb
+++ b/spec/system/02_after_login_spec.rb
@@ -65,6 +65,26 @@ describe '[STEP2] ユーザログイン後のテスト' do
         end
     end
     
+    describe 'トップ画面のテスト' do
+        before do
+            visit root_path
+        end
+        
+        context '表示内容の確認' do
+            it 'URLが正しい', spec_category: "ルーティング・URL設定の理解(ログイン状況に合わせた応用)" do
+                expect(current_path).to eq '/'
+            end
+            
+            it 'マイページリンクが表示されている', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+                expect(page).to have_link 'マイページ'
+            end
+            
+            it 'マイページのリンク先が正しい', spec_category: "基本的なアソシエーション概念と適切な変数設定" do
+                expect(page).to have_link 'マイページ', href: mypage_path    
+            end
+        end
+    end
+    
     describe 'マイページのテスト' do
         
         before do
@@ -775,7 +795,7 @@ describe '[STEP2] ユーザログイン後のテスト' do
             visit edit_user_path(user)
         end 
         
-        context '表示の確認' do
+        context '表示内容の確認' do
             it 'URLが正しい', spec_category: "CRUD機能に対するコントローラの処理と流れ(ログイン状況を意識した応用)" do
                 expect(current_path).to eq '/users/' + user.id.to_s + '/edit'
             end
@@ -839,7 +859,7 @@ describe '[STEP2] ユーザログイン後のテスト' do
             visit users_confirm_path(user)
         end
         
-        context '表示の確認' do
+        context '表示内容の確認' do
             it 'URLが正しい', spec_category: "CRUD機能に対するコントローラの処理と流れ(ログイン状況を意識した応用)" do
                expect(current_path).to eq '/users/' + user.id.to_s + '/confirm'    
             end
@@ -894,7 +914,7 @@ describe '[STEP2] ユーザログイン後のテスト' do
             visit edit_post_path(post)
         end
         
-        context '表示の確認' do
+        context '表示内容の確認' do
             it 'URLが正しい', spec_category: "CRUD機能に対するコントローラの処理と流れ(ログイン状況を意識した応用)" do
                 expect(current_path).to eq '/posts/' + post.id.to_s + '/edit'
             end


### PR DESCRIPTION
ユーザーがログイン後も、トップページに新規登録やログインのボタンが表示されたままだったので、ログイン後表示されなくなるように修正しました。
また、rspecテストにおいても、ログイン後のトップページのテスト項目を追加しました。